### PR TITLE
added responsive side drawer for mobile navigation

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -2,10 +2,12 @@ import React from "react";
 import Aux from "../../hoc/Aux";
 import classes from "./Layout.module.css";
 import Toolbar from "../Navigation/Toolbar/Toolbar";
+import SideDrawer from "../Navigation/SideDrawer/SideDrawer";
 const Layout = props => (
   <Aux>
     <div>
       <Toolbar />
+      <SideDrawer />
     </div>
     <main className={classes.Content}>{props.children}</main>
   </Aux>

--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -4,7 +4,7 @@ import classes from "./Logo.module.css";
 
 export default function Logo(props) {
   return (
-    <div className={classes.Logo}>
+    <div className={classes.Logo} style={{ height: props.height }}>
       <img src={burgerLogo} alt="burger" />
     </div>
   );

--- a/src/components/Navigation/NavigationItems/NavigationItem/NavigationItem.module.css
+++ b/src/components/Navigation/NavigationItems/NavigationItem/NavigationItem.module.css
@@ -1,17 +1,15 @@
 .NavigationItem {
-  margin: 0;
+  margin: 10px 0;
   box-sizing: border-box;
-  display: flex;
-  height: 100%;
+  display: block;
+  width: 100%;
   align-items: center;
 }
 
 .NavigationItem a {
-  color: white;
+  color: #8f5c2c;
   text-decoration: none;
-  height: 100%;
-  padding: 16px 10px;
-  border-bottom: 4px solid transparent;
+  width: 100%;
   box-sizing: border-box;
   display: block;
 }
@@ -19,7 +17,31 @@
 .NavigationItem a:hover,
 .NavigationItem a:active,
 .NavigationItem a.active {
-  background-color: #8f5c2c;
-  border-bottom: 4px solid #40a4c8;
-  color: white;
+  color: #40a4c8;
+}
+
+@media (min-width: 500px) {
+  .NavigationItem {
+    margin: 0;
+    display: flex;
+    height: 100%;
+    width: auto;
+    align-items: center;
+  }
+
+  .NavigationItem a {
+    color: white;
+    text-decoration: none;
+    height: 100%;
+    padding: 16px 10px;
+    border-bottom: 4px solid transparent;
+  }
+
+  .NavigationItem a:hover,
+  .NavigationItem a:active,
+  .NavigationItem a.active {
+    background-color: #8f5c2c;
+    border-bottom: 4px solid #40a4c8;
+    color: white;
+  }
 }

--- a/src/components/Navigation/NavigationItems/NavigationItems.module.css
+++ b/src/components/Navigation/NavigationItems/NavigationItems.module.css
@@ -3,6 +3,13 @@
   padding: 0;
   list-style: none;
   display: flex;
-  align-items: center;
+  flex-flow: column;
+
   height: 100%;
+}
+
+@media (min-width: 500px) {
+  .NavigationItems {
+    flex-flow: row;
+  }
 }

--- a/src/components/Navigation/SideDrawer/SideDrawer.js
+++ b/src/components/Navigation/SideDrawer/SideDrawer.js
@@ -1,0 +1,18 @@
+import React from "react";
+import Logo from "../../Logo/Logo";
+import NavigationItems from "../NavigationItems/NavigationItems";
+import classes from "./SideDrawer.module.css";
+
+export default function SideDrawer(props) {
+  return (
+    <div className={classes.SideDrawer}>
+      <div className={classes.Logo}>
+        <Logo />
+      </div>
+
+      <nav>
+        <NavigationItems />
+      </nav>
+    </div>
+  );
+}

--- a/src/components/Navigation/SideDrawer/SideDrawer.module.css
+++ b/src/components/Navigation/SideDrawer/SideDrawer.module.css
@@ -1,0 +1,31 @@
+.SideDrawer {
+  position: fixed;
+  width: 280px;
+  max-width: 70%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  z-index: 200;
+  background-color: white;
+  padding: 32px 16px;
+  box-sizing: border-box;
+  transition: transfrom 0.3s ease-out;
+}
+
+@media (min-width: 500px) {
+  .SideDrawer {
+    display: none;
+  }
+}
+
+.Open {
+  transform: translateX(0);
+}
+
+.Close {
+  transform: translateX(-100%);
+}
+.Logo {
+  height: 11%;
+  margin-bottom: 32px;
+}

--- a/src/components/Navigation/Toolbar/Toolbar.js
+++ b/src/components/Navigation/Toolbar/Toolbar.js
@@ -7,8 +7,10 @@ export default function Toolbar(props) {
   return (
     <header className={classes.Toolbar}>
       <div>Menu</div>
-      <Logo />
-      <nav>
+      <div className={classes.Logo}>
+        <Logo />
+      </div>
+      <nav className={classes.DesktopOnly}>
         <NavigationItems />
       </nav>
     </header>

--- a/src/components/Navigation/Toolbar/Toolbar.module.css
+++ b/src/components/Navigation/Toolbar/Toolbar.module.css
@@ -12,3 +12,17 @@
   box-sizing: border-box;
   z-index: 90;
 }
+
+.Toolbar nav {
+  height: 100%;
+}
+
+.Logo {
+  height: 80%;
+}
+
+@media (max-width: 499px) {
+  .DesktopOnly {
+    display: none;
+  }
+}


### PR DESCRIPTION
I have added a responsive side drawer that only appears in the mobile version of the site. The navbar for the desktop version is also hidden when the app is viewed in mobile.